### PR TITLE
Fix broken path in deploy example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,6 @@ $ clojure -X:build:prod uberjar :hyperfiddle/domain hello-fiddle :build/jar-name
 # Fly.io deployment
 
 ```shell
-$ fly deploy --remote-only --config src/hello_fiddle/fly.toml
+$ fly deploy --remote-only --config src-fiddles/hello_fiddle/fly.toml
 ```
 


### PR DESCRIPTION
hello_fiddle has moved from src/ to src-fiddles/, and I'm updating the README to match